### PR TITLE
Fix equalizer layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -623,10 +623,10 @@
           <div class="breath-bar">
             <div class="breath-progress" id="breathProgress"></div>
           </div>
-        </div>
-        <div class="equalizer-container">
-          <canvas id="leftEQ" class="equalizer" width="300" height="100"></canvas>
-          <canvas id="rightEQ" class="equalizer" width="300" height="100"></canvas>
+          <div class="equalizer-container">
+            <canvas id="leftEQ" class="equalizer" width="300" height="100"></canvas>
+            <canvas id="rightEQ" class="equalizer" width="300" height="100"></canvas>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- keep both equalizer canvases visible

## Testing
- `npm test`
- `pytest -q`
- `node server.js` *(fails: pyOpenBCI missing)*

------
https://chatgpt.com/codex/tasks/task_e_686b475122748324a38bb218e0c071cf