### PR TITLE
Improve audio quality and add session progress indicator

### DIFF
--- a/binaural_engine.js
+++ b/binaural_engine.js
@@ -8,6 +8,10 @@ class BinauralEngine {
     this.leftOsc = null;
     this.rightOsc = null;
     this.gainNode = gainNode || this.context.createGain();
+    this.filter = this.context.createBiquadFilter();
+    this.filter.type = "lowpass";
+    this.filter.frequency.value = 12000;
+    this.filter.connect(this.gainNode);
     this.gainNode.connect(this.context.destination);
     this.driftInterval = null;
     this.driftStep = 0;
@@ -26,10 +30,11 @@ class BinauralEngine {
     this.rightOsc.frequency.value = baseFreq + beatFreq;
     this.leftOsc.connect(merger, 0, 0);
     this.rightOsc.connect(merger, 0, 1);
-    merger.connect(this.gainNode);
-    this.setVolume(volume);
+    merger.connect(this.filter);
+    this.setVolume(0);
     if (this.leftOsc.start) this.leftOsc.start();
     if (this.rightOsc.start) this.rightOsc.start();
+    this.setVolume(volume);
   }
 
   update(baseFreq, beatFreq) {
@@ -90,16 +95,20 @@ class BinauralEngine {
 
   stop() {
     this.stopDrift();
+    const now = this.context.currentTime;
+    this.setVolume(0);
+    const stopAt = now + 0.1;
     if (this.leftOsc) {
-      if (this.leftOsc.stop) this.leftOsc.stop();
+      if (this.leftOsc.stop) this.leftOsc.stop(stopAt);
       this.leftOsc.disconnect();
       this.leftOsc = null;
     }
     if (this.rightOsc) {
-      if (this.rightOsc.stop) this.rightOsc.stop();
+      if (this.rightOsc.stop) this.rightOsc.stop(stopAt);
       this.rightOsc.disconnect();
       this.rightOsc = null;
     }
+    // leave filter connected for next session
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -380,6 +380,25 @@
         border-left: 4px solid #00ff88;
       }
 
+      .session-progress {
+        margin-top: 10px;
+      }
+
+      .progress-bar {
+        width: 100%;
+        height: 6px;
+        background: rgba(255, 255, 255, 0.1);
+        border-radius: 3px;
+        overflow: hidden;
+      }
+
+      .progress-fill {
+        width: 0%;
+        height: 100%;
+        background: linear-gradient(90deg, #0099ff, #ff0088);
+        transition: width 0.3s linear;
+      }
+
       .journal-section {
         background: rgba(255, 255, 255, 0.05);
         border: 1px solid rgba(255, 0, 136, 0.3);
@@ -841,6 +860,11 @@
             <div>
               <strong>Current Focus:</strong>
               <span id="currentFocus">None Selected</span>
+            </div>
+            <div class="session-progress">
+              <div class="progress-bar">
+                <div class="progress-fill" id="sessionProgress"></div>
+              </div>
             </div>
           </div>
         </div>
@@ -1360,6 +1384,8 @@
         async startSession() {
           try {
             await this.initializeAudio();
+            const progressEl = document.getElementById("sessionProgress");
+            if (progressEl) progressEl.style.width = "0%";
 
             const baseFreq = parseFloat(
               document.getElementById("baseFreq").value,
@@ -1677,6 +1703,8 @@
         }
 
         startSessionTimer() {
+          const progressEl = document.getElementById("sessionProgress");
+          progressEl.style.width = "0%";
           this.sessionTimer = setInterval(() => {
             const elapsed = Math.floor(
               (Date.now() - this.sessionStartTime) / 1000,
@@ -1685,6 +1713,10 @@
             const seconds = elapsed % 60;
             document.getElementById("sessionTimer").textContent =
               `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+            if (this.targetDuration) {
+              const pct = Math.min((elapsed / this.targetDuration) * 100, 100);
+              progressEl.style.width = `${pct}%`;
+            }
             if (this.targetDuration && elapsed >= this.targetDuration) {
               this.stopSession();
             }
@@ -1696,6 +1728,8 @@
             clearInterval(this.sessionTimer);
             this.sessionTimer = null;
           }
+          const progressEl = document.getElementById("sessionProgress");
+          if (progressEl) progressEl.style.width = "0%";
         }
 
         startBreathCoach() {


### PR DESCRIPTION
## Summary
- add lowpass filter and fade in/out to audio engine
- display session progress bar

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c8957fd4c8324b5689ebb717916ec