### PR TITLE
Improve audio smoothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ It broadcasts real‑time band power metrics over a WebSocket server.
 - **Session Journal** – record mood and insights
 - **Pattern Analysis** – discover optimal practice trends
 - **Affirmation Layer** – spoken positive cues during sessions
+- **Smooth Frequency Ramps** – crackle-free adjustments when changing tones
 - **Data Import/Export** – backup and restore your journal history
 - **Real-Time EEG Feedback** – optional audio adjustments via WebSocket
 - **Session Composer** – layer multiple sound tracks

--- a/TODO.md
+++ b/TODO.md
@@ -13,3 +13,4 @@
 - [x] Implement AI journal analysis and group synchronization
 - [x] Build analytics dashboard and custom frequency programming
 - [ ] Explore experimental protocols (entropy drift and more)
+- [x] Smooth frequency ramps to remove pops

--- a/binaural_engine.js
+++ b/binaural_engine.js
@@ -40,8 +40,11 @@ class BinauralEngine {
   update(baseFreq, beatFreq) {
     const now = this.context.currentTime;
     if (baseFreq !== undefined && this.leftOsc) {
+      if (this.leftOsc.frequency.cancelScheduledValues) {
+        this.leftOsc.frequency.cancelScheduledValues(now);
+      }
       if (this.leftOsc.frequency.setTargetAtTime) {
-        this.leftOsc.frequency.setTargetAtTime(baseFreq, now, 0.05);
+        this.leftOsc.frequency.setTargetAtTime(baseFreq, now, 0.1);
       }
       this.leftOsc.frequency.value = baseFreq;
     }
@@ -49,8 +52,11 @@ class BinauralEngine {
       const base = baseFreq !== undefined ? baseFreq : this.leftOsc.frequency.value;
       if (beatFreq !== undefined) {
         const freq = base + beatFreq;
+        if (this.rightOsc.frequency.cancelScheduledValues) {
+          this.rightOsc.frequency.cancelScheduledValues(now);
+        }
         if (this.rightOsc.frequency.setTargetAtTime) {
-          this.rightOsc.frequency.setTargetAtTime(freq, now, 0.05);
+          this.rightOsc.frequency.setTargetAtTime(freq, now, 0.1);
         }
         this.rightOsc.frequency.value = freq;
       }
@@ -59,8 +65,11 @@ class BinauralEngine {
 
   setVolume(vol) {
     const now = this.context.currentTime;
+    if (this.gainNode.gain.cancelScheduledValues) {
+      this.gainNode.gain.cancelScheduledValues(now);
+    }
     if (this.gainNode.gain.setTargetAtTime) {
-      this.gainNode.gain.setTargetAtTime(vol, now, 0.05);
+      this.gainNode.gain.setTargetAtTime(vol, now, 0.1);
     }
     this.gainNode.gain.value = vol;
   }
@@ -99,11 +108,20 @@ class BinauralEngine {
     this.setVolume(0);
     const stopAt = now + 0.1;
     if (this.leftOsc) {
+      if (this.leftOsc.frequency && this.leftOsc.frequency.cancelScheduledValues) {
+        this.leftOsc.frequency.cancelScheduledValues(now);
+      }
       if (this.leftOsc.stop) this.leftOsc.stop(stopAt);
       this.leftOsc.disconnect();
       this.leftOsc = null;
     }
     if (this.rightOsc) {
+      if (
+        this.rightOsc.frequency &&
+        this.rightOsc.frequency.cancelScheduledValues
+      ) {
+        this.rightOsc.frequency.cancelScheduledValues(now);
+      }
       if (this.rightOsc.stop) this.rightOsc.stop(stopAt);
       this.rightOsc.disconnect();
       this.rightOsc = null;

--- a/index.html
+++ b/index.html
@@ -1643,25 +1643,34 @@
 
           const now = this.audioContext.currentTime;
           if (this.leftOscillator && this.rightOscillator) {
+            if (this.leftOscillator.frequency.cancelScheduledValues) {
+              this.leftOscillator.frequency.cancelScheduledValues(now);
+            }
             if (this.leftOscillator.frequency.setTargetAtTime) {
-              this.leftOscillator.frequency.setTargetAtTime(baseFreq, now, 0.05);
+              this.leftOscillator.frequency.setTargetAtTime(baseFreq, now, 0.1);
             } else {
               this.leftOscillator.frequency.value = baseFreq;
             }
             const target = baseFreq + beatFreq;
+            if (this.rightOscillator.frequency.cancelScheduledValues) {
+              this.rightOscillator.frequency.cancelScheduledValues(now);
+            }
             if (this.rightOscillator.frequency.setTargetAtTime) {
-              this.rightOscillator.frequency.setTargetAtTime(target, now, 0.05);
+              this.rightOscillator.frequency.setTargetAtTime(target, now, 0.1);
             } else {
               this.rightOscillator.frequency.value = target;
             }
           }
 
           if (this.isochronicOscillator) {
+            if (this.isochronicOscillator.frequency.cancelScheduledValues) {
+              this.isochronicOscillator.frequency.cancelScheduledValues(now);
+            }
             if (this.isochronicOscillator.frequency.setTargetAtTime) {
               this.isochronicOscillator.frequency.setTargetAtTime(
                 beatFreq,
                 now,
-                0.05,
+                0.1,
               );
             } else {
               this.isochronicOscillator.frequency.value = beatFreq;
@@ -1670,8 +1679,11 @@
 
           if (this.phaseDelayNode) {
             const delay = phaseShift / 360 / baseFreq;
+            if (this.phaseDelayNode.delayTime.cancelScheduledValues) {
+              this.phaseDelayNode.delayTime.cancelScheduledValues(now);
+            }
             if (this.phaseDelayNode.delayTime.setTargetAtTime) {
-              this.phaseDelayNode.delayTime.setTargetAtTime(delay, now, 0.05);
+              this.phaseDelayNode.delayTime.setTargetAtTime(delay, now, 0.1);
             } else {
               this.phaseDelayNode.delayTime.value = delay;
             }


### PR DESCRIPTION
## Summary
- add smoother frequency ramps with cancelScheduledValues
- mention the improvement in README
- update TODO for completed task

## Testing
- `npm install`
- `npm test`
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`
- `node server.js` *(terminated after launch)*
- `python python/eeg_bridge.py` *(fails: pyOpenBCI library is required)*

------
https://chatgpt.com/codex/tasks/task_e_686c9222ffc88324a4a7137bc8d82878