### PR TITLE
Add UI theme toggle and sessions API

### DIFF
--- a/binaural_engine.js
+++ b/binaural_engine.js
@@ -15,6 +15,8 @@ class BinauralEngine {
     this.gainNode.connect(this.context.destination);
     this.driftInterval = null;
     this.driftStep = 0;
+    this.isochronicOsc = null;
+    this.isoGain = null;
     this.waveType = "sine";
   }
 
@@ -78,6 +80,27 @@ class BinauralEngine {
     this.waveType = type;
     if (this.leftOsc) this.leftOsc.type = type;
     if (this.rightOsc) this.rightOsc.type = type;
+  }
+  startIsochronic(rate = 10, volume = 0.1) {
+    this.stopIsochronic();
+    this.isochronicOsc = this.context.createOscillator();
+    this.isoGain = this.context.createGain();
+    this.isochronicOsc.type = "square";
+    this.isochronicOsc.frequency.value = rate;
+    this.isochronicOsc.connect(this.isoGain);
+    this.isoGain.gain.value = volume;
+    this.isoGain.connect(this.gainNode);
+    if (this.isochronicOsc.start) this.isochronicOsc.start();
+  }
+
+  stopIsochronic() {
+    if (this.isochronicOsc) {
+      if (this.isochronicOsc.stop) this.isochronicOsc.stop();
+      this.isochronicOsc.disconnect();
+      this.isoGain.disconnect();
+      this.isochronicOsc = null;
+      this.isoGain = null;
+    }
   }
 
   startDrift(period = 60, min = 3, max = 7) {

--- a/index.html
+++ b/index.html
@@ -25,6 +25,20 @@
         min-height: 100vh;
         overflow-x: hidden;
       }
+      body.light-mode {
+        background: radial-gradient(circle at 50% 50%, #ffffff 0%, #dddddd 100%);
+        color: #000000;
+      }
+
+      body.light-mode .control-panel {
+        background: rgba(0, 0, 0, 0.05);
+        border-color: rgba(0, 0, 0, 0.2);
+      }
+
+      body.light-mode .visualization-area {
+        background: radial-gradient(circle at center, rgba(255, 255, 255, 0.4) 0%, rgba(255, 255, 255, 0.2) 100%);
+        border-color: rgba(0, 0, 0, 0.3);
+      }
 
       .container {
         max-width: 1200px;
@@ -562,6 +576,10 @@
         text-decoration: underline;
       }
 
+      .theme-switch {
+        margin-top: 10px;
+        display: inline-block;
+      }
       .instructions {
         margin-bottom: 20px;
         text-align: center;
@@ -611,7 +629,9 @@
           target="_blank"
           class="github-link"
           >View on GitHub</a
-        >
+        <label class="theme-switch">
+          <input type="checkbox" id="themeToggle" /> Light Mode
+        </label>
       </header>
 
       <div class="instructions">
@@ -1629,24 +1649,14 @@
         }
 
         startIsochronicPulse(frequency, volume) {
-          this.isochronicOscillator = this.audioContext.createOscillator();
-          const isoGain = this.audioContext.createGain();
-
-          this.isochronicOscillator.type = "square";
-          this.isochronicOscillator.frequency.value = frequency;
-
-          this.isochronicOscillator.connect(isoGain);
-          isoGain.connect(this.gainNode);
-          isoGain.gain.value = volume * 0.2;
-
-          this.isochronicOscillator.start();
+          if (this.engine) {
+            this.engine.startIsochronic(frequency, volume * 0.2);
+          }
         }
 
         stopIsochronicPulse() {
-          if (this.isochronicOscillator) {
-            this.isochronicOscillator.stop();
-            this.isochronicOscillator.disconnect();
-            this.isochronicOscillator = null;
+          if (this.engine) {
+            this.engine.stopIsochronic();
           }
         }
 
@@ -2509,6 +2519,21 @@
       // Create app instance on DOM ready
       document.addEventListener("DOMContentLoaded", () => {
         app = new HemiLabGateway();
+          const themeToggle = document.getElementById("themeToggle");
+          const storedTheme = localStorage.getItem("hemilab_theme") || "dark";
+          if (storedTheme === "light") {
+            document.body.classList.add("light-mode");
+            themeToggle.checked = true;
+          }
+          themeToggle.addEventListener("change", () => {
+            if (themeToggle.checked) {
+              document.body.classList.add("light-mode");
+              localStorage.setItem("hemilab_theme", "light");
+            } else {
+              document.body.classList.remove("light-mode");
+              localStorage.setItem("hemilab_theme", "dark");
+            }
+          });
       
         // Add some initial guidance
         const welcomeMessage = `

--- a/tests/binaural_engine.test.js
+++ b/tests/binaural_engine.test.js
@@ -47,4 +47,14 @@ describe('BinauralEngine', () => {
     expect(engine.rightOsc.type).toBe('sawtooth');
     engine.stop();
   });
+
+  test('isochronic oscillator starts and stops', () => {
+    const engine = new BinauralEngine();
+    engine.start(100, 4);
+    engine.startIsochronic(5, 0.2);
+    expect(engine.isochronicOsc.frequency.value).toBe(5);
+    engine.stopIsochronic();
+    expect(engine.isochronicOsc).toBeNull();
+    engine.stop();
+  });
 });

--- a/tests/server_api.test.js
+++ b/tests/server_api.test.js
@@ -60,3 +60,28 @@ test('group broadcast stays within group', (done) => {
     }, 100);
   });
 });
+
+test('create and fetch sessions', async () => {
+  const sessionsFile = path.join(__dirname, 'test_sessions.json');
+  process.env.SESSIONS_FILE = sessionsFile;
+  jest.resetModules();
+  const { start } = require('../server');
+  const srv = start(0, 50);
+  const port = srv.address().port;
+  const base = `http://localhost:${port}`;
+
+  let res = await fetch(base + '/api/sessions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user: 'bob', focus: 10 }),
+  });
+  expect(res.status).toBe(200);
+
+  res = await fetch(base + '/api/sessions?user=bob');
+  const list = await res.json();
+  expect(list.length).toBe(1);
+  expect(list[0].user).toBe('bob');
+
+  srv.close();
+  fs.unlinkSync(sessionsFile);
+});

--- a/tests/test_eeg_bridge.py
+++ b/tests/test_eeg_bridge.py
@@ -31,6 +31,7 @@ def bridge() -> eeg_bridge.EEGBridge:
     br.ws_port = 0
     br.loop = asyncio.new_event_loop()
     br.buffer = []
+    br.output_file = None
     return br
 
 
@@ -71,3 +72,10 @@ def test_compute_bandpower_returns_average(bridge: eeg_bridge.EEGBridge) -> None
 
     assert "average" in metrics
     assert set(metrics["average"].keys()) == set(eeg_bridge.BANDS.keys())
+
+
+def test_log_metrics_writes_file(tmp_path, bridge: eeg_bridge.EEGBridge) -> None:
+    file = tmp_path / "metrics.jsonl"
+    bridge.output_file = str(file)
+    bridge.log_metrics({"foo": 1})
+    assert json.loads(file.read_text().strip()) == {"foo": 1}


### PR DESCRIPTION
## Summary
- enable optional light mode theme in UI
- add isochronic support to the binaural engine
- provide EEG logging with CLI options
- implement sessions API in backend
- expand automated tests for new features

## Testing
- `npm test`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d478e89b4832496e6cddf7c731fd9