### PR TITLE
Add compressor stage with configurable settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -791,6 +791,61 @@
               />
             </div>
             <div class="control-group">
+              <label>
+                Compressor Threshold (dB):
+                <span id="compThresholdValue">-24</span>
+              </label>
+              <input
+                type="range"
+                class="slider"
+                id="compThreshold"
+                min="-100"
+                max="0"
+                value="-24"
+              />
+            </div>
+            <div class="control-group">
+              <label>
+                Compressor Ratio: <span id="compRatioValue">12</span>
+              </label>
+              <input
+                type="range"
+                class="slider"
+                id="compRatio"
+                min="1"
+                max="20"
+                value="12"
+              />
+            </div>
+            <div class="control-group">
+              <label>
+                Attack (s): <span id="compAttackValue">0.003</span>
+              </label>
+              <input
+                type="range"
+                class="slider"
+                id="compAttack"
+                min="0"
+                max="1"
+                step="0.001"
+                value="0.003"
+              />
+            </div>
+            <div class="control-group">
+              <label>
+                Release (s): <span id="compReleaseValue">0.25</span>
+              </label>
+              <input
+                type="range"
+                class="slider"
+                id="compRelease"
+                min="0"
+                max="1"
+                step="0.01"
+                value="0.25"
+              />
+            </div>
+            <div class="control-group">
               <label
                 >Phase Shift (°): <span id="phaseShiftValue">0</span></label
               >
@@ -1163,7 +1218,21 @@
               window.webkitAudioContext)();
             this.gainNode = this.audioContext.createGain();
             this.gainNode.connect(this.audioContext.destination);
-            this.engine = new BinauralEngine(this.audioContext, this.gainNode);
+            const compSettings = {
+              threshold: parseFloat(
+                document.getElementById("compThreshold").value,
+              ),
+              ratio: parseFloat(document.getElementById("compRatio").value),
+              attack: parseFloat(document.getElementById("compAttack").value),
+              release: parseFloat(
+                document.getElementById("compRelease").value,
+              ),
+            };
+            this.engine = new BinauralEngine(
+              this.audioContext,
+              this.gainNode,
+              compSettings,
+            );
             this.initEqualizer();
           }
 
@@ -1232,6 +1301,54 @@
               }
             }
           });
+
+          document
+            .getElementById("compThreshold")
+            .addEventListener("input", (e) => {
+              document.getElementById("compThresholdValue").textContent =
+                e.target.value;
+              if (this.engine) {
+                this.engine.setCompressorSettings({
+                  threshold: parseFloat(e.target.value),
+                });
+              }
+            });
+
+          document
+            .getElementById("compRatio")
+            .addEventListener("input", (e) => {
+              document.getElementById("compRatioValue").textContent =
+                e.target.value;
+              if (this.engine) {
+                this.engine.setCompressorSettings({
+                  ratio: parseFloat(e.target.value),
+                });
+              }
+            });
+
+          document
+            .getElementById("compAttack")
+            .addEventListener("input", (e) => {
+              document.getElementById("compAttackValue").textContent =
+                e.target.value;
+              if (this.engine) {
+                this.engine.setCompressorSettings({
+                  attack: parseFloat(e.target.value),
+                });
+              }
+            });
+
+          document
+            .getElementById("compRelease")
+            .addEventListener("input", (e) => {
+              document.getElementById("compReleaseValue").textContent =
+                e.target.value;
+              if (this.engine) {
+                this.engine.setCompressorSettings({
+                  release: parseFloat(e.target.value),
+                });
+              }
+            });
 
           document
             .getElementById("phaseShift")

--- a/tests/binaural_engine.test.js
+++ b/tests/binaural_engine.test.js
@@ -57,4 +57,24 @@ describe('BinauralEngine', () => {
     expect(engine.isochronicOsc).toBeNull();
     engine.stop();
   });
+
+  test('compressor settings can be updated', () => {
+    const engine = new BinauralEngine(null, null, {
+      threshold: -30,
+      ratio: 10,
+      attack: 0.01,
+      release: 0.5,
+    });
+    expect(engine.compressor.threshold.value).toBeCloseTo(-30);
+    engine.setCompressorSettings({
+      threshold: -20,
+      ratio: 4,
+      attack: 0.005,
+      release: 0.3,
+    });
+    expect(engine.compressor.threshold.value).toBeCloseTo(-20);
+    expect(engine.compressor.ratio.value).toBeCloseTo(4);
+    expect(engine.compressor.attack.value).toBeCloseTo(0.005);
+    expect(engine.compressor.release.value).toBeCloseTo(0.3);
+  });
 });


### PR DESCRIPTION
## Summary
- insert a dynamics compressor after the binaural filter and route through gain for consistent levels
- expose threshold, ratio, attack, and release controls with UI sliders and update handlers
- cover compressor configuration with new unit test

## Testing
- `npm test`
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b763f86f84832484f03f23a1463b0b