### PR TITLE
Add configurable filter controls to binaural engine

### DIFF
--- a/binaural_engine.js
+++ b/binaural_engine.js
@@ -1,5 +1,11 @@
 class BinauralEngine {
-  constructor(context, gainNode, compressorOptions = {}) {
+  constructor(
+    context,
+    gainNode,
+    compressorOptions = {},
+    filterType = "lowpass",
+    filterFrequency = 12000,
+  ) {
     this.context =
       context ||
       new (typeof AudioContext !== "undefined"
@@ -9,8 +15,7 @@ class BinauralEngine {
     this.rightOsc = null;
     this.gainNode = gainNode || this.context.createGain();
     this.filter = this.context.createBiquadFilter();
-    this.filter.type = "lowpass";
-    this.filter.frequency.value = 12000;
+    this.setFilter(filterType, filterFrequency);
     this.compressor = this.context.createDynamicsCompressor();
     const {
       threshold = -24,
@@ -92,6 +97,17 @@ class BinauralEngine {
     this.waveType = type;
     if (this.leftOsc) this.leftOsc.type = type;
     if (this.rightOsc) this.rightOsc.type = type;
+  }
+
+  setFilter(type = "lowpass", frequency = 12000) {
+    if (type === "none") {
+      this.filter.type = "allpass";
+    } else {
+      this.filter.type = type;
+      if (frequency !== undefined) {
+        this.filter.frequency.value = frequency;
+      }
+    }
   }
 
   setCompressorSettings(settings = {}) {

--- a/index.html
+++ b/index.html
@@ -846,6 +846,28 @@
               />
             </div>
             <div class="control-group">
+              <label>Filter Type:</label>
+              <select id="filterType">
+                <option value="none">None</option>
+                <option value="lowpass" selected>Low-pass</option>
+                <option value="highpass">High-pass</option>
+                <option value="bandpass">Band-pass</option>
+              </select>
+            </div>
+            <div class="control-group">
+              <label>
+                Cutoff Frequency (Hz): <span id="filterFreqValue">12000</span>
+              </label>
+              <input
+                type="range"
+                class="slider"
+                id="filterFreq"
+                min="20"
+                max="20000"
+                value="12000"
+              />
+            </div>
+            <div class="control-group">
               <label
                 >Phase Shift (°): <span id="phaseShiftValue">0</span></label
               >
@@ -1228,10 +1250,16 @@
                 document.getElementById("compRelease").value,
               ),
             };
+            const filterType = document.getElementById("filterType").value;
+            const filterFreq = parseFloat(
+              document.getElementById("filterFreq").value,
+            );
             this.engine = new BinauralEngine(
               this.audioContext,
               this.gainNode,
               compSettings,
+              filterType,
+              filterFreq,
             );
             this.initEqualizer();
           }
@@ -1349,6 +1377,33 @@
                 });
               }
             });
+
+          document
+            .getElementById("filterType")
+            .addEventListener("change", (e) => {
+              const freqSlider = document.getElementById("filterFreq");
+              freqSlider.disabled = e.target.value === "none";
+              if (this.engine) {
+                this.engine.setFilter(
+                  e.target.value,
+                  parseFloat(freqSlider.value),
+                );
+              }
+            });
+
+          document
+            .getElementById("filterFreq")
+            .addEventListener("input", (e) => {
+              document.getElementById("filterFreqValue").textContent =
+                e.target.value;
+              const type = document.getElementById("filterType").value;
+              if (this.engine && type !== "none") {
+                this.engine.setFilter(type, parseFloat(e.target.value));
+              }
+            });
+
+          document.getElementById("filterFreq").disabled =
+            document.getElementById("filterType").value === "none";
 
           document
             .getElementById("phaseShift")
@@ -1737,6 +1792,9 @@
               const eng = new BinauralEngine(
                 this.audioContext,
                 this.audioContext.createGain(),
+                {},
+                document.getElementById("filterType").value,
+                parseFloat(document.getElementById("filterFreq").value),
               );
               eng.gainNode.connect(this.gainNode);
               eng.start(b, beat, vol, waveType);
@@ -2373,6 +2431,9 @@
             const eng = new BinauralEngine(
               this.audioContext,
               this.audioContext.createGain(),
+              {},
+              document.getElementById("filterType").value,
+              parseFloat(document.getElementById("filterFreq").value),
             );
             eng.gainNode.connect(this.gainNode);
             eng.start(

--- a/tests/binaural_engine.test.js
+++ b/tests/binaural_engine.test.js
@@ -77,4 +77,15 @@ describe('BinauralEngine', () => {
     expect(engine.compressor.attack.value).toBeCloseTo(0.005);
     expect(engine.compressor.release.value).toBeCloseTo(0.3);
   });
+
+  test('filter settings can be adjusted', () => {
+    const engine = new BinauralEngine(null, null, {}, 'highpass', 5000);
+    expect(engine.filter.type).toBe('highpass');
+    expect(engine.filter.frequency.value).toBeCloseTo(5000);
+    engine.setFilter('none');
+    expect(engine.filter.type).toBe('allpass');
+    engine.setFilter('lowpass', 200);
+    expect(engine.filter.type).toBe('lowpass');
+    expect(engine.filter.frequency.value).toBeCloseTo(200);
+  });
 });


### PR DESCRIPTION
## Summary
- add filter type and cutoff parameters to `BinauralEngine` constructor and expose `setFilter`
- introduce UI dropdown and slider to control or bypass audio filter
- expand tests for filter behavior and wire filter options through engine initialization

## Testing
- `npm test`
- `python -m pytest tests/test_eeg_bridge.py` *(fails: async def functions are not natively supported)*
- `node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68b76572adec8324878affd4f574358c