### PR TITLE
Schedule drift with configurable waveforms

### DIFF
--- a/index.html
+++ b/index.html
@@ -924,6 +924,13 @@
               </label>
             </div>
             <div class="control-group">
+              <label for="driftWaveform">Drift Waveform</label>
+              <select id="driftWaveform">
+                <option value="sine">Sine</option>
+                <option value="triangle">Triangle</option>
+              </select>
+            </div>
+            <div class="control-group">
               <label>
                 <input type="checkbox" id="entropyMode" /> Entropy Drift
               </label>
@@ -1483,10 +1490,24 @@
               .addEventListener("change", (e) => {
                 if (this.engine) {
                   if (e.target.checked) {
-                    this.engine.startDrift();
+                    const wave = document.getElementById("driftWaveform").value;
+                    this.engine.startDrift(undefined, undefined, undefined, wave);
                   } else {
                     this.engine.stopDrift();
                   }
+                }
+              });
+
+            document
+              .getElementById("driftWaveform")
+              .addEventListener("change", (e) => {
+                if (this.engine && document.getElementById("driftMode").checked) {
+                  this.engine.startDrift(
+                    undefined,
+                    undefined,
+                    undefined,
+                    e.target.value,
+                  );
                 }
               });
 
@@ -1779,7 +1800,8 @@
             this.engine.setWaveType(waveType);
             this.engine.gainNode = this.gainNode;
             if (document.getElementById("driftMode").checked) {
-              this.engine.startDrift();
+              const wave = document.getElementById("driftWaveform").value;
+              this.engine.startDrift(undefined, undefined, undefined, wave);
             }
 
             // Start composed layers
@@ -2485,6 +2507,7 @@
             isochronicMode: document.getElementById("isochronicMode").checked,
             deepBassMode: document.getElementById("deepBassMode").checked,
             driftMode: document.getElementById("driftMode").checked,
+            driftWaveform: document.getElementById("driftWaveform").value,
             entropyMode: document.getElementById("entropyMode").checked,
             rebalMode: document.getElementById("rebalMode").checked,
             breathCoachMode: document.getElementById("breathCoachMode").checked,

--- a/tests/binaural_engine.test.js
+++ b/tests/binaural_engine.test.js
@@ -27,15 +27,28 @@ describe('BinauralEngine', () => {
     expect(engine.gainNode.gain.value).toBeCloseTo(0.2);
   });
 
-  test('drift mode sweeps beat frequency', () => {
+  test('drift mode schedules sine waveform with setValueCurveAtTime', () => {
     const engine = new BinauralEngine();
     engine.start(100, 3);
-    engine.startDrift(1, 3, 7);
-    expect(engine.rightOsc.frequency.value).toBeCloseTo(103);
-    jest.advanceTimersByTime(500);
-    expect(engine.rightOsc.frequency.value).toBeCloseTo(107, 1);
-    jest.advanceTimersByTime(500);
-    expect(engine.rightOsc.frequency.value).toBeCloseTo(103, 1);
+    const spy = jest.spyOn(engine.rightOsc.frequency, 'setValueCurveAtTime');
+    engine.startDrift(1, 3, 7, 'sine');
+    expect(spy).toHaveBeenCalledTimes(1);
+    jest.advanceTimersByTime(1000);
+    expect(spy).toHaveBeenCalledTimes(2);
+    engine.stop();
+  });
+
+  test('drift mode schedules triangle waveform with linear ramps', () => {
+    const engine = new BinauralEngine();
+    engine.start(100, 3);
+    const spy = jest.spyOn(engine.rightOsc.frequency, 'linearRampToValueAtTime');
+    const now = engine.context.currentTime;
+    engine.startDrift(1, 3, 7, 'triangle');
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[0][0]).toBe(107);
+    expect(spy.mock.calls[0][1]).toBeCloseTo(now + 0.5);
+    expect(spy.mock.calls[1][0]).toBe(103);
+    expect(spy.mock.calls[1][1]).toBeCloseTo(now + 1);
     engine.stop();
   });
 


### PR DESCRIPTION
## Summary
- Replace interval-based drift with AudioParam automation
- Add sine/triangle waveform selection and UI control
- Expand tests for waveform-based scheduling

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8af2824c8832498516c89af0bc235